### PR TITLE
ci: use sr-releaser GitHub App for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SR_RELEASER_APP_ID }}
+          private-key: ${{ secrets.SR_RELEASER_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -111,7 +120,7 @@ jobs:
         id: sr
         uses: urmzd/sr@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           force: ${{ inputs.force }}
           artifacts: "release-assets/*"
 


### PR DESCRIPTION
## Summary
- Use `sr-releaser` GitHub App token instead of `GITHUB_TOKEN` for release commits
- Enables signed commits and branch ruleset bypass

## Test plan
- [ ] Verify PR checks pass
- [ ] Merge and confirm release workflow succeeds with app token