### PR TITLE
fix: download binary from floating tag instead of latest release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "embed-src"
-version = "3.3.1"
+version = "3.4.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/urmzd/embed-src/actions/workflows/ci.yml"><img src="https://github.com/urmzd/embed-src/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://crates.io/crates/embed-src"><img src="https://img.shields.io/crates/v/embed-src" alt="crates.io"></a>
 </p>
 
 ## Showcase


### PR DESCRIPTION
## Summary
- **Fix action binary download**: derive a floating major-version tag (e.g. `v3`) from `GITHUB_ACTION_REF` instead of using `/releases/latest/download/`, which can point to an older major version after a new release.
- **Add `author` field** to `action.yml`.
- **Housekeeping**: bump `Cargo.lock` to v3.4.0 and add crates.io version badge to README.

## Test plan
- [ ] Verify the action resolves the correct download URL when referenced as `urmzd/embed-src@v3`
- [ ] Confirm fallback to `latest` when ref is not a semver tag