### PR TITLE
chore: remove unused ui::header function

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,15 +1,6 @@
 use crossterm::style::Stylize;
 use std::io::{self, Write};
 
-/// Print a cyan bold header with a 40-char dim rule beneath it.
-#[allow(dead_code)]
-pub fn header(text: &str) {
-    let mut err = io::stderr().lock();
-    let rule = "─".repeat(40);
-    let _ = writeln!(err, "  {}", text.cyan().bold());
-    let _ = writeln!(err, "  {}", rule.dim());
-}
-
 /// Print a green bold checkmark with a message.
 pub fn phase_ok(text: &str) {
     let mut err = io::stderr().lock();


### PR DESCRIPTION
## Summary
- Remove the `header()` function from `src/ui.rs` — it was never called anywhere in the codebase

## Test plan
- [x] `cargo check` passes