### PR TITLE
chore: add linguist overrides to fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,30 @@
 *.woff2 binary
 *.ttf binary
 *.eot binary
+
+# ── Linguist overrides ──────────────────────────────────────────────────────
+# Prevent non-code files from skewing GitHub language statistics
+
+# Markup / documentation
+*.html linguist-documentation
+*.css linguist-documentation
+*.scss linguist-documentation
+*.tex linguist-documentation
+*.ipynb linguist-documentation
+
+# Config / infrastructure
+Justfile linguist-vendored
+justfile linguist-vendored
+Makefile linguist-vendored
+Dockerfile linguist-vendored
+*.dockerfile linguist-vendored
+*.nix linguist-vendored
+*.sh linguist-vendored
+
+# Generated output
+*.svg linguist-generated
+dist/ linguist-generated
+build/ linguist-generated
+out/ linguist-generated
+target/ linguist-generated
+


### PR DESCRIPTION
## Summary
- Add linguist directives to `.gitattributes` so GitHub language statistics reflect actual programming languages
- Mark HTML/CSS/TeX/ipynb as `linguist-documentation`
- Mark Shell/Makefile/Dockerfile/Justfile/Nix as `linguist-vendored`
- Mark SVG and build output dirs (dist, build, target) as `linguist-generated`

## Why
Non-code files (HTML artifacts, CSS, shell scripts, build configs) were inflating language stats and obscuring the real tech stack on GitHub profile and repo pages.

## Test plan
- [x] No code changes — only `.gitattributes` metadata
- [ ] Verify language bar updates after merge (GitHub recalculates on next push)