### PR TITLE
refactor: inline agentspec-update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "agentspec-update"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b41cf13d5f1daaf731e67a34204d20c6c9d362256361a982787cb0a1f83399"
-dependencies = [
- "anyhow",
- "serde",
- "serde_json",
- "sha2",
- "ureq",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,13 +351,17 @@ dependencies = [
 
 [[package]]
 name = "fsrc"
-version = "3.6.1"
+version = "4.0.0"
 dependencies = [
- "agentspec-update",
+ "anyhow",
  "clap",
  "crossterm",
  "indicatif",
  "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,8 @@ clap = { version = "4", features = ["derive"] }
 crossterm = "0.28"
 indicatif = "0.17"
 regex = "1"
-agentspec-update = "0.6.0"
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+ureq = { version = "3", features = ["json"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod self_update;
+
 use std::path::Path;
 use std::process;
 
@@ -60,11 +62,11 @@ fn main() {
         }
         Command::Update => {
             eprintln!("current version: {}", env!("CARGO_PKG_VERSION"));
-            match agentspec_update::self_update("urmzd/fsrc", env!("CARGO_PKG_VERSION"), "fsrc") {
-                Ok(agentspec_update::UpdateResult::AlreadyUpToDate) => {
+            match self_update::self_update("urmzd/fsrc", env!("CARGO_PKG_VERSION"), "fsrc") {
+                Ok(self_update::UpdateResult::AlreadyUpToDate) => {
                     eprintln!("already up to date")
                 }
-                Ok(agentspec_update::UpdateResult::Updated { from, to }) => {
+                Ok(self_update::UpdateResult::Updated { from, to }) => {
                     eprintln!("updated: {from} → {to}")
                 }
                 Err(e) => {

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -104,11 +104,7 @@ fn atomic_replace(target: &PathBuf, new_bytes: &[u8]) -> Result<()> {
 /// `binary_name` — name prefix in release assets (e.g., "sr").
 ///
 /// Assets are expected to be named `{binary_name}-{target}` (e.g., `sr-x86_64-apple-darwin`).
-pub fn self_update(
-    repo: &str,
-    current_version: &str,
-    binary_name: &str,
-) -> Result<UpdateResult> {
+pub fn self_update(repo: &str, current_version: &str, binary_name: &str) -> Result<UpdateResult> {
     let release = fetch_latest_release(repo)?;
     let latest_version = release.tag_name.trim_start_matches('v');
 

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,0 +1,161 @@
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct ReleaseAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<ReleaseAsset>,
+}
+
+/// Result of a self-update check.
+#[derive(Debug)]
+pub enum UpdateResult {
+    /// Already on the latest version.
+    AlreadyUpToDate,
+    /// Updated from old to new version.
+    Updated { from: String, to: String },
+}
+
+/// Detect the current platform target triple.
+fn detect_target() -> Result<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-musl"),
+        ("linux", "aarch64") => Ok("aarch64-unknown-linux-musl"),
+        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
+        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
+        ("windows", "x86_64") => Ok("x86_64-pc-windows-msvc"),
+        (os, arch) => bail!("unsupported platform: {os}/{arch}"),
+    }
+}
+
+fn gh_get(url: &str) -> Result<ureq::Body> {
+    let mut req = ureq::get(url).header("Accept", "application/vnd.github+json");
+
+    if let Ok(token) = std::env::var("GH_TOKEN").or_else(|_| std::env::var("GITHUB_TOKEN")) {
+        req = req.header("Authorization", format!("token {token}"));
+    }
+
+    let resp = req.call().context("HTTP request failed")?;
+    Ok(resp.into_body())
+}
+
+fn fetch_latest_release(repo: &str) -> Result<Release> {
+    let url = format!("https://api.github.com/repos/{repo}/releases/latest");
+    let mut body = gh_get(&url)?;
+    let release: Release = body.read_json().context("failed to parse release JSON")?;
+    Ok(release)
+}
+
+fn download_bytes(url: &str) -> Result<Vec<u8>> {
+    let body = gh_get(url)?;
+    let mut bytes = Vec::new();
+    body.into_reader()
+        .read_to_end(&mut bytes)
+        .context("failed to read response body")?;
+    Ok(bytes)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Atomically replace a binary file with new content.
+fn atomic_replace(target: &PathBuf, new_bytes: &[u8]) -> Result<()> {
+    let backup = target.with_extension("old");
+    let tmp = target.with_extension("new");
+
+    fs::write(&tmp, new_bytes).context("failed to write new binary")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755))
+            .context("failed to set executable permissions")?;
+    }
+
+    if target.exists() {
+        fs::rename(target, &backup).context("failed to backup current binary")?;
+    }
+    if let Err(e) = fs::rename(&tmp, target) {
+        if backup.exists() {
+            let _ = fs::rename(&backup, target);
+        }
+        return Err(e).context("failed to replace binary");
+    }
+
+    let _ = fs::remove_file(&backup);
+    Ok(())
+}
+
+/// Self-update the current binary from GitHub Releases.
+///
+/// `repo` — "owner/name" format (e.g., "urmzd/sr").
+/// `current_version` — current version string (without "v" prefix).
+/// `binary_name` — name prefix in release assets (e.g., "sr").
+///
+/// Assets are expected to be named `{binary_name}-{target}` (e.g., `sr-x86_64-apple-darwin`).
+pub fn self_update(
+    repo: &str,
+    current_version: &str,
+    binary_name: &str,
+) -> Result<UpdateResult> {
+    let release = fetch_latest_release(repo)?;
+    let latest_version = release.tag_name.trim_start_matches('v');
+
+    if latest_version == current_version {
+        return Ok(UpdateResult::AlreadyUpToDate);
+    }
+
+    let target = detect_target()?;
+    let asset_name = format!("{binary_name}-{target}");
+
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == asset_name)
+        .ok_or_else(|| anyhow::anyhow!("no asset found for {asset_name}"))?;
+
+    // Check for a .sha256 sidecar file.
+    let sha256_name = format!("{asset_name}.sha256");
+    let expected_sha256 = release
+        .assets
+        .iter()
+        .find(|a| a.name == sha256_name)
+        .and_then(|a| {
+            download_bytes(&a.browser_download_url)
+                .ok()
+                .and_then(|b| String::from_utf8(b).ok())
+                .map(|s| s.trim().split_whitespace().next().unwrap_or("").to_string())
+        });
+
+    eprintln!("downloading {binary_name} {latest_version} for {target}...");
+
+    let bytes = download_bytes(&asset.browser_download_url)?;
+
+    if let Some(expected) = &expected_sha256 {
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let actual = hex_encode(&hasher.finalize());
+        if actual != *expected {
+            bail!("SHA256 mismatch: expected {expected}, got {actual}");
+        }
+    }
+
+    let current_exe = std::env::current_exe().context("cannot determine current executable")?;
+    atomic_replace(&current_exe, &bytes)?;
+
+    Ok(UpdateResult::Updated {
+        from: current_version.to_string(),
+        to: latest_version.to_string(),
+    })
+}

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -131,7 +131,7 @@ pub fn self_update(repo: &str, current_version: &str, binary_name: &str) -> Resu
             download_bytes(&a.browser_download_url)
                 .ok()
                 .and_then(|b| String::from_utf8(b).ok())
-                .map(|s| s.trim().split_whitespace().next().unwrap_or("").to_string())
+                .map(|s| s.split_whitespace().next().unwrap_or("").to_string())
         });
 
     eprintln!("downloading {binary_name} {latest_version} for {target}...");


### PR DESCRIPTION
## Summary
- Removed external `agentspec-update` crate dependency
- Vendored the ~160-line self-update logic as `src/self_update.rs`
- Added `anyhow`, `serde`, `serde_json`, `sha2`, `ureq` deps (previously transitive through agentspec-update)

## Test plan
- [x] `cargo check` passes
- [ ] CI green