### PR TITLE
fix(ci): migrate sr v4 to v7 for artifact and input support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
           fetch-depth: 0
       - name: Check for releasable commits
         id: plan
-        uses: urmzd/sr@v4
+        uses: urmzd/sr@v7
         with:
-          command: plan
+          dry-run: "true"
 
   build:
     needs: plan
@@ -138,7 +138,7 @@ jobs:
 
       - name: Release
         id: sr
-        uses: urmzd/sr@v4
+        uses: urmzd/sr@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           force: ${{ inputs.force }}

--- a/sr.yaml
+++ b/sr.yaml
@@ -1,38 +1,62 @@
-# sr v4 configuration
+# sr v7 configuration
 # Reference: https://github.com/urmzd/sr#configuration
 
-commit:
-  pattern: ^(?P<type>\w+)(?:\((?P<scope>[^)]+)\))?(?P<breaking>!)?:\s+(?P<description>.+)
-  breaking_section: Breaking Changes
-  misc_section: Miscellaneous
-  types:
-  - name: feat
-    bump: minor
-    section: Features
-  - name: fix
-    bump: patch
-    section: Bug Fixes
-  - name: perf
-    bump: patch
-    section: Performance
-  - name: docs
-    section: Documentation
-  - name: refactor
-    bump: patch
-    section: Refactoring
-  - name: revert
-    section: Reverts
-  - name: chore
-  - name: ci
-  - name: test
-  - name: build
-  - name: style
-release:
-  branches:
-  - main
+git:
   tag_prefix: v
-  changelog:
-    file: CHANGELOG.md
-  version_files:
-  - Cargo.toml
-  floating_tags: true
+  floating_tag: true
+
+commit:
+  types:
+    minor:
+      - feat
+    patch:
+      - fix
+      - perf
+      - refactor
+    none:
+      - docs
+      - revert
+      - chore
+      - ci
+      - test
+      - build
+      - style
+
+changelog:
+  file: CHANGELOG.md
+  groups:
+    - name: breaking
+      content:
+        - breaking
+    - name: features
+      content:
+        - feat
+    - name: bug-fixes
+      content:
+        - fix
+    - name: performance
+      content:
+        - perf
+    - name: refactoring
+      content:
+        - refactor
+    - name: misc
+      content:
+        - docs
+        - revert
+        - chore
+        - ci
+        - test
+        - build
+        - style
+
+channels:
+  default: stable
+  branch: main
+  content:
+    - name: stable
+
+packages:
+  - path: .
+    version_files:
+      - Cargo.toml


### PR DESCRIPTION
## Summary
- sr v4 silently ignores `artifacts` and `force` action inputs, so release binaries are not attached to GitHub releases
- Upgrades action from `urmzd/sr@v4` to `urmzd/sr@v7`
- Migrates `sr.yaml` from v4 to v7 config format (grouped commit types, top-level `changelog`/`channels`/`packages` sections)

## Test plan
- [ ] Merge and verify next release attaches binaries (if applicable)
- [ ] Verify `force` input works on `workflow_dispatch`